### PR TITLE
show display log for ethash gen fn

### DIFF
--- a/ethash.go
+++ b/ethash.go
@@ -257,6 +257,7 @@ func (d *dag) generate() {
 			d.dir = DefaultDir
 		}
 		glog.V(logger.Info).Infof("Generating DAG for epoch %d (size %d) (%x)", d.epoch, dagSize, seedHash)
+		glog.D(logger.Error).Infof("Generating DAG for epoch %d [size %d] (%x)", d.epoch, dagSize, seedHash)
 		// Generate a temporary cache.
 		// TODO: this could share the cache with Light
 		cache := C.ethash_light_new_internal(cacheSize, (*C.ethash_h256_t)(unsafe.Pointer(&seedHash[0])))
@@ -289,6 +290,7 @@ func (d *dag) Ptr() unsafe.Pointer {
 //export ethashGoCallback
 func ethashGoCallback(percent C.unsigned) C.int {
 	glog.V(logger.Info).Infof("Generating DAG: %d%%", percent)
+	glog.D(logger.Error).Infof("Generating DAG: %d%%", percent)
 	return 0
 }
 


### PR DESCRIPTION
This function is called from `geth make-dag`.

problem: Without implementing the `.D` logs, all progress verbosity goes to FS debug logs.
solution: Add `.D` log lines. Ethash already imports `ethereumproject/geth/logger/glog` so `D` fn is present there.
  
I use `Error` verbosity because it should be a high-priority visibility.